### PR TITLE
fix Library.h - issue #25

### DIFF
--- a/include/asl/Library.h
+++ b/include/asl/Library.h
@@ -130,7 +130,7 @@ class Library
 	void open(String file, bool tryprefix=true)
 	{
 		if(file.indexOf('.', 2) < 0)
-			file += ASL_LIB_EXT;
+			file += "." ASL_LIB_EXT;
 #ifdef _WIN32
 		file.replaceme('/', '\\');
 		_lib = LoadLibrary(file);


### PR DESCRIPTION
- add "." to the system specific library extension when extension is not provided in the library name string